### PR TITLE
Adding ability to specify unit identifier when creating client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./src/jsModbus.js",

--- a/src/jsModbus.js
+++ b/src/jsModbus.js
@@ -8,7 +8,7 @@ exports.setLogger = function (logger) {
     handler.setLogger(logger);
 };
 
-exports.createTCPClient = function (port, host, cb) {
+exports.createTCPClient = function (port, host, unit_id, cb) {
 
     var net             = require('net'),
     tcpClientModule     = require('./tcpClient'),
@@ -16,10 +16,24 @@ exports.createTCPClient = function (port, host, cb) {
 
     tcpClientModule.setLogger(log);
     serialClientModule.setLogger(log);
+    
+    // retrieve arguments as array
+    var args = [];
+    for (var i = 0; i < arguments.length; i++) {
+        args.push(arguments[i]);
+    }
+    // first argument is the port, 2nd argument is the host   
+    port = args.shift();
+    host = args.shift();
+    // last argument is the callback function.    
+    cb = args.pop();
+
+    // if args still holds items, this is the unit_id
+    if (args.length > 0) unit_id = args.shift(); else unit_id = 1;  //default to 1
 
     var socket    = net.connect(port, host),
-        tcpClient = tcpClientModule.create(socket);
-
+        tcpClient = tcpClientModule.create(socket, unit_id);
+    
     socket.on('error', function (e) {
 
         if (!cb) {

--- a/src/tcpClient.js
+++ b/src/tcpClient.js
@@ -9,19 +9,18 @@ exports.setLogger = function (logger) {
     log = logger;
 };
 
-var PROTOCOL_VERSION = 0,
-    UNIT_ID = 1;
-
+var PROTOCOL_VERSION = 0;
+    
 /**
  *  ModbusTCPClient handles the MBAP that is the
  *  additional header used for modbus tcp protocol.
  *  It get's initialised with a simple socket providing
  *  .on, .emit and .write methods
  */
-var ModbusTCPClient = function (socket) {
+var ModbusTCPClient = function (socket, unit_id) {
 
     if (!(this instanceof ModbusTCPClient)) {
-        return new ModbusTCPClient(socket);
+        return new ModbusTCPClient(socket, unit_id);
     }
 
     EventEmitter.call(this);
@@ -47,7 +46,7 @@ var ModbusTCPClient = function (socket) {
         .word16be(this.reqId++)      // transaction id
         .word16be(PROTOCOL_VERSION)  // protocol version
         .word16be(pdu.length + 1)    // pdu length
-        .word8(UNIT_ID)              // unit id
+        .word8(typeof unit_id === 'number' ? unit_id:true)	// unit id
         .put(pdu)                    // the actual pdu
         .buffer();
 


### PR DESCRIPTION
Added the ability to specify a unit identifier when creating a modbus tcp client.  Should also still be backward compatible.  I also created the necessary tests.